### PR TITLE
Fix demo crashing bugs

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -60,4 +60,5 @@ dependencies {
     implementation("com.google.zxing:core:3.5.0")
     implementation("com.journeyapps:zxing-android-embedded:4.3.0")
     implementation("com.google.firebase:firebase-storage-ktx:20.2.1")
+    implementation("com.google.android.gms:play-services:17.0.0")
 }

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -60,5 +60,4 @@ dependencies {
     implementation("com.google.zxing:core:3.5.0")
     implementation("com.journeyapps:zxing-android-embedded:4.3.0")
     implementation("com.google.firebase:firebase-storage-ktx:20.2.1")
-    implementation("com.google.android.gms:play-services:17.0.0")
 }

--- a/app/src/androidTest/java/com/example/lotto649/AdminManageProfileTest.java
+++ b/app/src/androidTest/java/com/example/lotto649/AdminManageProfileTest.java
@@ -18,8 +18,11 @@ import static org.hamcrest.core.IsEqual.equalTo;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
+import android.net.Uri;
 import android.provider.Settings;
+import android.util.Log;
 
+import androidx.lifecycle.MutableLiveData;
 import androidx.test.espresso.Espresso;
 import androidx.test.espresso.IdlingRegistry;
 import androidx.test.espresso.matcher.BoundedMatcher;
@@ -30,6 +33,9 @@ import com.google.firebase.firestore.DocumentReference;
 import com.google.firebase.firestore.DocumentSnapshot;
 import com.google.firebase.firestore.FirebaseFirestore;
 import com.google.firebase.firestore.SetOptions;
+import com.google.firebase.storage.FirebaseStorage;
+import com.google.firebase.storage.StorageReference;
+import com.google.firebase.storage.UploadTask;
 
 import org.hamcrest.Description;
 import org.hamcrest.Matcher;
@@ -37,11 +43,39 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import java.net.URI;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.atomic.AtomicReference;
 
 @RunWith(AndroidJUnit4.class)
 public class AdminManageProfileTest {
+
+    public static void uploadProfileImageToFirebaseStorage(Uri imageUri, String fileName, AtomicReference<String> currentImageUriString) {
+        if (imageUri == null) {
+            return;
+        }
+
+        FirebaseStorage storage = FirebaseStorage.getInstance("gs://shower-lotto649.firebasestorage.app");
+        StorageReference storageRef = storage.getReference().child("profileImages/" + fileName);
+        UploadTask uploadTask = storageRef.putFile(imageUri);
+        uploadTask.addOnSuccessListener(taskSnapshot -> {
+            storageRef.getDownloadUrl().addOnSuccessListener(uri -> {
+                String uriString = uri.toString();
+                currentImageUriString.set(uriString);
+            });
+        });
+        try {
+            Log.e("JASON TEST", "GOING TO AWAIT TASK");
+            com.google.android.gms.tasks.Tasks.await(uploadTask);
+            Log.e("JASON TEST", "DONE AWAITING TASK");
+        } catch (ExecutionException e) {
+            e.printStackTrace();
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        }
+    }
 
     @Rule
     public ActivityScenarioRule<MainActivity> activityRule = new ActivityScenarioRule<>(MainActivity.class);
@@ -131,11 +165,19 @@ public class AdminManageProfileTest {
     }
 
 
+    // TODO: currently fails - look into https://stackoverflow.com/questions/43004365/firebase-storage-wait-for-listeners
     @Test
     public void testDeleteProfilePicture() {
         FirebaseFirestore db = FirebaseFirestore.getInstance();
         //     create admin profile to test with
         String deviceId = Settings.Secure.getString(getContext().getContentResolver(), Settings.Secure.ANDROID_ID);
+
+        Uri imageUri = Uri.parse("https://upload.wikimedia.org/wikipedia/commons/thumb/2/2f/Google_2015_logo.svg/1920px-Google_2015_logo.svg.png");
+
+        AtomicReference<String> currentImageUriString = new AtomicReference<String>("");
+
+        uploadProfileImageToFirebaseStorage(imageUri, "testFile", currentImageUriString);
+
         DocumentReference userRef = db.collection("users").document(deviceId);
         userRef.set(new HashMap<String, Object>() {{
             put("name", "John Tester");
@@ -154,7 +196,7 @@ public class AdminManageProfileTest {
         data.put("name", "Testy Test");
         data.put("organizer", false);
         data.put("phone", "");
-        data.put("profileImage", "");
+        data.put("profileImage", currentImageUriString.get());
         // document set so it is first in list
         DocumentReference testRef = db.collection("users").document("1111111111111111111111111uitest1");
         testRef.set(data, SetOptions.merge());
@@ -216,6 +258,11 @@ public class AdminManageProfileTest {
 
         // delete test entry from db
         testRef.delete();
+
+        // delete test image from storage
+        FirebaseStorage storage = FirebaseStorage.getInstance("gs://shower-lotto649.firebasestorage.app");
+        StorageReference storageRef = storage.getReference().child("profileImages/testFile");
+        storageRef.delete();
 
         IdlingRegistry.getInstance().unregister(idlingResource);
     }

--- a/app/src/main/java/com/example/lotto649/Controllers/AccountUserController.java
+++ b/app/src/main/java/com/example/lotto649/Controllers/AccountUserController.java
@@ -67,6 +67,16 @@ public class AccountUserController extends AbstractController {
     }
 
     /**
+     * Updates the user model with new data. This method is used to modify the
+     * state of the `UserModel` and trigger any necessary updates.
+     *
+     * @param image the updated user phone
+     */
+    public void updateImage(String image) {
+        getModel().setProfileImage(image);
+    }
+
+    /**
      * Gets if the user has been saved to firebase
      *
      * @return a boolean representing if the user has been saved to firebase
@@ -78,11 +88,12 @@ public class AccountUserController extends AbstractController {
     /**
      * Save the user to firestore for data retention
      */
-    public void saveToFirestore(String name, String email, String phone) {
+    public void saveToFirestore(String name, String email, String phone, String image) {
         UserModel user = getModel();
         user.setName(name);
         user.setEmail(email);
         user.setPhone(phone);
+        user.setProfileImage(image);
         user.saveUserToFirestore();
     }
 }

--- a/app/src/main/java/com/example/lotto649/Models/FacilityModel.java
+++ b/app/src/main/java/com/example/lotto649/Models/FacilityModel.java
@@ -28,19 +28,6 @@ public class FacilityModel extends AbstractModel {
     }
 
     /**
-     * Constructor to create a new facility with a deviceId and facility name.
-     * Address is set to "".
-     *
-     * @param deviceId the deviceId of the organizer that created the facility
-     * @param facilityName the name of the facility being created
-     */
-    public FacilityModel(String deviceId, String facilityName) {
-        this.facilityName = facilityName;
-        this.deviceId = deviceId;
-        this.address = "";
-    }
-
-    /**
      * Constructor to create a new facility with a deviceId, facility name, and optional address.
      *
      * @param deviceId the deviceId of the organizer that created the facility

--- a/app/src/main/java/com/example/lotto649/Views/ArrayAdapters/BrowseEventsArrayAdapter.java
+++ b/app/src/main/java/com/example/lotto649/Views/ArrayAdapters/BrowseEventsArrayAdapter.java
@@ -7,6 +7,7 @@ package com.example.lotto649.Views.ArrayAdapters;
 
 import android.content.Context;
 import android.net.Uri;
+import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -90,7 +91,7 @@ public class BrowseEventsArrayAdapter extends ArrayAdapter<EventModel> {
 
 
         String posterUriString = event.getPosterImage();
-        if (!Objects.equals(posterUriString, "")) {
+        if (posterUriString != null && !Objects.equals(posterUriString, "")) {
             posterUri = Uri.parse(posterUriString);
             StorageReference imageRef = FirebaseStorage.getInstance("gs://shower-lotto649.firebasestorage.app").getReferenceFromUrl(posterUriString);
             imageRef.getDownloadUrl().addOnSuccessListener(uri -> {

--- a/app/src/main/java/com/example/lotto649/Views/ArrayAdapters/BrowseFacilitiesArrayAdapter.java
+++ b/app/src/main/java/com/example/lotto649/Views/ArrayAdapters/BrowseFacilitiesArrayAdapter.java
@@ -51,12 +51,7 @@ public class BrowseFacilitiesArrayAdapter extends ArrayAdapter<FacilityModel> {
             TextView address = view.findViewById(R.id.facility_address);
             TextView numOpenEvents = view.findViewById(R.id.facility_open_events);
             facilityName.setText(facility.getFacilityName());
-            if (facility.getAddress().isEmpty()) {
-                address.setVisibility(View.GONE);
-            } else {
-                address.setVisibility(View.VISIBLE);
-                address.setText(facility.getAddress());
-            }
+            address.setText(facility.getAddress());
             // TODO: update with actual number of open events at facility
             numOpenEvents.setText("Number of Open Events: 0");
             return view;

--- a/app/src/main/java/com/example/lotto649/Views/Fragments/AccountFragment.java
+++ b/app/src/main/java/com/example/lotto649/Views/Fragments/AccountFragment.java
@@ -210,7 +210,7 @@ public class AccountFragment extends Fragment {
                 initialEmailInput = email;
                 initialPhoneInput = phone;
                 imagePlaceholder.setText(user.getInitials());
-                SetSaveButtonColor(true);
+                SetSaveButtonVisibility(true);
 
                 // Update profile Image
                 if (!Objects.equals(profileImageUri, "")) {
@@ -269,7 +269,7 @@ public class AccountFragment extends Fragment {
                 String fileName = deviceId + ".jpg";
                 // https://stackoverflow.com/questions/1068760/can-i-pass-parameters-by-reference-in-java
                 FirebaseStorageHelper.uploadProfileImageToFirebaseStorage(currentImageUri, fileName, currentImageUriString, imageAbleToBeDeleted);
-                SetSaveButtonColor(true);
+                SetSaveButtonVisibility(true);
                 if (!userController.getSavedToFirebase()) {
                     userController.saveToFirestore(name, email, phone, currentImageUriString.get());
                 } else {
@@ -399,7 +399,7 @@ public class AccountFragment extends Fragment {
         public void beforeTextChanged(CharSequence s, int start, int count, int after) {}
 
         public void onTextChanged(CharSequence s, int start, int before, int count) {
-            SetSaveButtonColor(DidInfoRemainConstant());
+            SetSaveButtonVisibility(DidInfoRemainConstant());
         }
     };
 
@@ -412,7 +412,7 @@ public class AccountFragment extends Fragment {
         public void beforeTextChanged(CharSequence s, int start, int count, int after) {}
 
         public void onTextChanged(CharSequence s, int start, int before, int count) {
-            SetSaveButtonColor(DidInfoRemainConstant());
+            SetSaveButtonVisibility(DidInfoRemainConstant());
         }
     };
 
@@ -425,7 +425,7 @@ public class AccountFragment extends Fragment {
         public void beforeTextChanged(CharSequence s, int start, int count, int after) {}
 
         public void onTextChanged(CharSequence s, int start, int before, int count) {
-            SetSaveButtonColor(DidInfoRemainConstant());
+            SetSaveButtonVisibility(DidInfoRemainConstant());
         }
     };
 
@@ -434,21 +434,13 @@ public class AccountFragment extends Fragment {
      *
      * @param isEqual if the facility information inputted is the same as in Firestore
      */
-    private void SetSaveButtonColor(boolean isEqual) {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
-            RippleDrawable saveBackgroundColor = (RippleDrawable) saveButton.getBackground();
-            if (isEqual) {
-                if (saveBackgroundColor.getEffectColor().getDefaultColor() != getResources().getColor(R.color.lightSurfaceContainerHigh, null)) {
-                    saveButton.setBackgroundColor(getResources().getColor(R.color.lightSurfaceContainerHigh, null));
-                    saveButton.setTextColor(getResources().getColor(R.color.lightPrimary, null));
-                }
-            }
-            else {
-                if (saveBackgroundColor.getEffectColor().getDefaultColor() != getResources().getColor(R.color.lightOnSurface, null)) {
-                    saveButton.setBackgroundColor(getResources().getColor(R.color.colorPrimary, null));
-                    saveButton.setTextColor(getResources().getColor(R.color.black, null));
-                }
-            }
+    private void SetSaveButtonVisibility(boolean isEqual) {
+        if (isEqual) {
+            saveButton.setVisibility(View.GONE);
+            nameInputLayout.setError(null);
+            emailInputLayout.setError(null);
+        } else {
+            saveButton.setVisibility(View.VISIBLE);
         }
     }
 
@@ -472,7 +464,7 @@ public class AccountFragment extends Fragment {
             profileImage.setImageURI(currentImageUri);
             imageAbleToBeDeleted.setValue(Boolean.TRUE);
             hasSetImage = true;
-            SetSaveButtonColor(false);
+            SetSaveButtonVisibility(false);
         } else {
             if (!hasSetImage) {
                 Log.e("JASON TEST", "REMOVING IMAGE");

--- a/app/src/main/java/com/example/lotto649/Views/Fragments/AdminEventFragment.java
+++ b/app/src/main/java/com/example/lotto649/Views/Fragments/AdminEventFragment.java
@@ -199,21 +199,13 @@ public class AdminEventFragment extends Fragment {
         deleteQRButton.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View view) {
-                StorageReference storageReference = FirebaseStorage.getInstance("gs://shower-lotto649.firebasestorage.app")
-                        .getReferenceFromUrl("qrcodes/" + firestoreEventId + ".png");
-                storageReference.delete()
+                eventsRef
+                        .document(firestoreEventId)
+                        .update("qrCode", "")
                         .addOnSuccessListener(new OnSuccessListener<Void>() {
                             @Override
-                            public void onSuccess(Void unused) {
-                                eventsRef
-                                        .document(firestoreEventId)
-                                        .update("qrCode", "")
-                                        .addOnSuccessListener(new OnSuccessListener<Void>() {
-                                            @Override
-                                            public void onSuccess(Void aVoid) {
-                                                //add success log
-                                            }
-                                        });
+                            public void onSuccess(Void aVoid) {
+                                //add success log
                             }
                         });
             }

--- a/app/src/main/java/com/example/lotto649/Views/Fragments/AdminEventFragment.java
+++ b/app/src/main/java/com/example/lotto649/Views/Fragments/AdminEventFragment.java
@@ -17,6 +17,8 @@ import android.widget.TextView;
 
 import androidx.annotation.NonNull;
 import androidx.fragment.app.Fragment;
+import androidx.lifecycle.MutableLiveData;
+import androidx.lifecycle.Observer;
 
 import com.bumptech.glide.Glide;
 import com.example.lotto649.Models.UserModel;
@@ -46,7 +48,20 @@ public class AdminEventFragment extends Fragment {
     private CollectionReference eventsRef;
     private String firestoreEventId;
     private ImageView posterImage;
+    TextView name;
+    TextView status;
+    TextView location;
+    TextView spotsAvail;
+    TextView numAttendees;
+    TextView dates;
+    TextView geoLocation;
+    TextView description;
+    Button deleteImageButton;
+    Button deleteQRButton;
+    Button deleteEventButton;
     private Uri posterUri;
+    private MutableLiveData<Boolean> imageAbleToBeDeleted;
+    private MutableLiveData<Boolean> qrCodeAbleToBeDeleted;
 
     /**
      * Public empty constructor for BrowseEventsFragment.
@@ -75,22 +90,48 @@ public class AdminEventFragment extends Fragment {
         // Inflate the layout for this fragment
         View view = inflater.inflate(R.layout.fragment_admin_view_event, container, false);
 
+        imageAbleToBeDeleted = new MutableLiveData<Boolean>(Boolean.FALSE);
+        // https://stackoverflow.com/questions/14457711/android-listening-for-variable-changes
+        imageAbleToBeDeleted.observe(getViewLifecycleOwner(), new Observer<Boolean>() {
+            @Override
+            public void onChanged(Boolean changedValue) {
+                if (Objects.equals(changedValue, Boolean.TRUE)) {
+                    deleteImageButton.setVisibility(View.VISIBLE);
+                } else {
+                    deleteImageButton.setVisibility(View.GONE);
+                }
+            }
+        });
+
+        qrCodeAbleToBeDeleted = new MutableLiveData<Boolean>(Boolean.FALSE);
+        // https://stackoverflow.com/questions/14457711/android-listening-for-variable-changes
+        qrCodeAbleToBeDeleted.observe(getViewLifecycleOwner(), new Observer<Boolean>() {
+            @Override
+            public void onChanged(Boolean changedValue) {
+                if (Objects.equals(changedValue, Boolean.TRUE)) {
+                    deleteQRButton.setVisibility(View.VISIBLE);
+                } else {
+                    deleteQRButton.setVisibility(View.GONE);
+                }
+            }
+        });
+
         // initialize Firestore
         db = FirebaseFirestore.getInstance();
         eventsRef = db.collection("events");
 
-        TextView name = view.findViewById(R.id.admin_event_name);
-        TextView status = view.findViewById(R.id.admin_event_status);
-        TextView location = view.findViewById(R.id.admin_event_location);
-        TextView spotsAvail = view.findViewById(R.id.admin_event_spots);
-        TextView numAttendees = view.findViewById(R.id.admin_event_attendees);
-        TextView dates = view.findViewById(R.id.admin_event_dates);
-        TextView geoLocation = view.findViewById(R.id.admin_event_geo);
-        TextView description = view.findViewById(R.id.admin_event_description);
+        name = view.findViewById(R.id.admin_event_name);
+        status = view.findViewById(R.id.admin_event_status);
+        location = view.findViewById(R.id.admin_event_location);
+        spotsAvail = view.findViewById(R.id.admin_event_spots);
+        numAttendees = view.findViewById(R.id.admin_event_attendees);
+        dates = view.findViewById(R.id.admin_event_dates);
+        geoLocation = view.findViewById(R.id.admin_event_geo);
+        description = view.findViewById(R.id.admin_event_description);
+        deleteImageButton = view.findViewById(R.id.admin_delete_event_image);
+        deleteQRButton = view.findViewById(R.id.admin_delete_event_qr);
+        deleteEventButton = view.findViewById(R.id.admin_delete_event);
         posterImage = view.findViewById(R.id.admin_event_poster);
-        Button deleteImageButton = view.findViewById(R.id.admin_delete_event_image);
-        Button deleteQRButton = view.findViewById(R.id.admin_delete_event_qr);
-        Button deleteEventButton = view.findViewById(R.id.admin_delete_event);
 
         eventsRef.document(firestoreEventId)
                 .get()
@@ -131,9 +172,17 @@ public class AdminEventFragment extends Fragment {
                             }
                             description.setText(descriptionText);
 
+                            String qrCode = doc.getString("qrCode");
+                            if (qrCode == null || qrCode.isEmpty()) {
+                                qrCodeAbleToBeDeleted.setValue(Boolean.FALSE);
+                            } else {
+                                qrCodeAbleToBeDeleted.setValue(Boolean.TRUE);
+                            }
+
                         //     poster
                             String posterUriString = doc.getString("posterImage");
                             if (!Objects.equals(posterUriString, "")) {
+                                imageAbleToBeDeleted.setValue(Boolean.TRUE);
                                 posterUri = Uri.parse(posterUriString);
                                 StorageReference imageRef = FirebaseStorage.getInstance("gs://shower-lotto649.firebasestorage.app").getReferenceFromUrl(posterUriString);
                                 imageRef.getDownloadUrl().addOnSuccessListener(uri -> {
@@ -145,6 +194,7 @@ public class AdminEventFragment extends Fragment {
                                 });
                             } else {
                                 posterUri = null;
+                                imageAbleToBeDeleted.setValue(Boolean.FALSE);
                             }
                         }
                     }
@@ -188,6 +238,7 @@ public class AdminEventFragment extends Fragment {
                                                     //     add success log
                                                 }
                                             });
+                                    imageAbleToBeDeleted.setValue(Boolean.FALSE);
                                     posterUri = null;
                                     posterImage.setImageResource(R.drawable.ic_person_foreground);
                                 }
@@ -205,6 +256,7 @@ public class AdminEventFragment extends Fragment {
                         .addOnSuccessListener(new OnSuccessListener<Void>() {
                             @Override
                             public void onSuccess(Void aVoid) {
+                                qrCodeAbleToBeDeleted.setValue(Boolean.FALSE);
                                 //add success log
                             }
                         });

--- a/app/src/main/java/com/example/lotto649/Views/Fragments/FacilityFragment.java
+++ b/app/src/main/java/com/example/lotto649/Views/Fragments/FacilityFragment.java
@@ -109,7 +109,7 @@ public class FacilityFragment extends Fragment {
                         facility.setAddress(addressText);
                         initialFacilityNameInput = nameText;
                         initialAddressInput = addressText;
-                        SetSaveButtonColor(true);
+                        SetSaveButtonVisibility(true);
                         Log.d("Firestore", String.format("deviceId %s got name=%s, address=%s ", deviceId, nameText, addressText));
                     } else {
                         Log.d("Firestore", "No such document");
@@ -147,7 +147,7 @@ public class FacilityFragment extends Fragment {
                 facilityController.saveToFirestore();
                 initialFacilityNameInput = facilityName;
                 initialAddressInput = address;
-                SetSaveButtonColor(true);
+                SetSaveButtonVisibility(true);
             }
         });
 
@@ -183,21 +183,13 @@ public class FacilityFragment extends Fragment {
      *
      * @param isEqual if the facility information inputted is the same as in Firestore
      */
-    private void SetSaveButtonColor(boolean isEqual) {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
-            RippleDrawable saveBackgroundColor = (RippleDrawable) save.getBackground();
-            if (isEqual) {
-                if (saveBackgroundColor.getEffectColor().getDefaultColor() != getResources().getColor(R.color.lightSurfaceContainerHigh, null)) {
-                    save.setBackgroundColor(getResources().getColor(R.color.lightSurfaceContainerHigh, null));
-                    save.setTextColor(getResources().getColor(R.color.lightPrimary, null));
-                }
-            }
-            else {
-                if (saveBackgroundColor.getEffectColor().getDefaultColor() != getResources().getColor(R.color.lightOnSurface, null)) {
-                    save.setBackgroundColor(getResources().getColor(R.color.colorPrimary, null));
-                    save.setTextColor(getResources().getColor(R.color.black, null));
-                }
-            }
+    private void SetSaveButtonVisibility(boolean isEqual) {
+        if (isEqual) {
+            save.setVisibility(View.GONE);
+            nameInput.setError(null);
+            addressInput.setError(null);
+        } else {
+            save.setVisibility(View.VISIBLE);
         }
     }
 
@@ -210,7 +202,7 @@ public class FacilityFragment extends Fragment {
         public void beforeTextChanged(CharSequence s, int start, int count, int after) {}
 
         public void onTextChanged(CharSequence s, int start, int before, int count) {
-            SetSaveButtonColor(DidInfoRemainConstant());
+            SetSaveButtonVisibility(DidInfoRemainConstant());
         }
     };
 
@@ -223,7 +215,7 @@ public class FacilityFragment extends Fragment {
         public void beforeTextChanged(CharSequence s, int start, int count, int after) {}
 
         public void onTextChanged(CharSequence s, int start, int before, int count) {
-            SetSaveButtonColor(DidInfoRemainConstant());
+            SetSaveButtonVisibility(DidInfoRemainConstant());
         }
     };
 }

--- a/app/src/main/java/com/example/lotto649/Views/Fragments/FacilityFragment.java
+++ b/app/src/main/java/com/example/lotto649/Views/Fragments/FacilityFragment.java
@@ -130,11 +130,16 @@ public class FacilityFragment extends Fragment {
             public void onClick(View view) {
                 // reset error message
                 nameInput.setError(null);
+                addressInput.setError(null);
                 String facilityName = nameInput.getEditableText().toString();
                 String address = addressInput.getEditableText().toString();
                 // If no facility name given, error
                 if (facilityName.isEmpty()) {
                     nameInput.setError("Please enter a facility name");
+                    return;
+                }
+                if (address.isEmpty()) {
+                    addressInput.setError("Please enter an address");
                     return;
                 }
                 facilityController.updateFacilityName(facilityName);

--- a/app/src/main/res/layout/fragment_facility.xml
+++ b/app/src/main/res/layout/fragment_facility.xml
@@ -63,7 +63,7 @@
             android:layout_marginEnd="24dp"
             android:hint="Address"
             app:helperTextEnabled="true"
-            app:helperText="Optional"
+            app:helperText="Required"
             app:endIconMode="custom"
             app:endIconDrawable="@drawable/facility_icon">
 

--- a/app/src/test/java/com/example/lotto649/AccountUserControllerTest.java
+++ b/app/src/test/java/com/example/lotto649/AccountUserControllerTest.java
@@ -78,11 +78,13 @@ public class AccountUserControllerTest {
         String name = "Tester";
         String email = "test@example.com";
         String phone = "1234567";
-        accountUserController.saveToFirestore(name, email, phone);
+        String profileImage = "imageUriString";
+        accountUserController.saveToFirestore(name, email, phone, profileImage);
 
         verify(mockUserModel).setName(name);
         verify(mockUserModel).setEmail(email);
         verify(mockUserModel).setPhone(phone);
+        verify(mockUserModel).setProfileImage(profileImage);
 
         verify(mockUserModel).saveUserToFirestore(); // Verify that saveUserToFirestore was called
     }


### PR DESCRIPTION
Fixing a few bugs and addressing some feedback from the demo and generally part 3.

This includes

1. [Viewing events as an admin (crash)](https://github.com/CMPUT301F24shower/shower-lotto649/issues/17)
2. [Removing a QR code from event as an admin (crash)](https://github.com/CMPUT301F24shower/shower-lotto649/issues/18)
3. [Removing a non-saved image from profile (crash)](https://github.com/CMPUT301F24shower/shower-lotto649/issues/22)
4. [Making facility address required](https://github.com/CMPUT301F24shower/shower-lotto649/issues/21)
5. [Changing button visibilities](https://github.com/CMPUT301F24shower/shower-lotto649/issues/23)

The only buttons not fully functioning as expected yet are in event creation/editing. This is covered in [this issue](https://github.com/CMPUT301F24shower/shower-lotto649/issues/30).